### PR TITLE
feat: add automated release and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: Publish Package to npm
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version type (patch/minor/major)'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org/'
+      
+      - name: Git config
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Bump version
+        run: |
+          npm version ${{ github.event.inputs.version_type }} -m "Release %s"
+          git push
+          git push --tags

--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
     "prepare": "husky",
     "start": "node dist/cli.js",
     "test": "jest",
-    "prepublishOnly": "npm run clean && npm run build"
+    "prepublishOnly": "npm run clean && npm run build",
+    "release:patch": "npm version patch && git push --follow-tags",
+    "release:minor": "npm version minor && git push --follow-tags",
+    "release:major": "npm version major && git push --follow-tags"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.10",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,7 @@
     "prepare": "husky",
     "start": "node dist/cli.js",
     "test": "jest",
-    "prepublishOnly": "npm run clean && npm run build",
-    "release:patch": "npm version patch && git push --follow-tags",
-    "release:minor": "npm version minor && git push --follow-tags",
-    "release:major": "npm version major && git push --follow-tags"
+    "prepublishOnly": "npm run clean && npm run build"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.10",


### PR DESCRIPTION
This PR adds:

1. GitHub Action workflow for automated releases:
   - Manual trigger with version type selection (patch/minor/major)
   - Automatic version bumping and tag creation
   - Pushes changes and tags

2. GitHub Action workflow for npm publishing:
   - Triggered by tag pushes
   - Handles building and publishing to npm
   - Uses NPM_TOKEN for authentication

3. Improved build process:
   - Added clean step before builds
   - Fixed external dependencies in esbuild config
   - Updated mistralai dependency version

To use:
1. Add NPM_TOKEN to repository secrets
2. Use the 'Create Release' action in GitHub Actions
3. Select version type and run workflow