### PR TITLE
fix: add synchronize event to workflow

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -4,7 +4,7 @@ run-name: Changeset Release ${{ github.actor != 'github-actions[bot]' && '- Crea
 on:
   workflow_dispatch:
   pull_request:
-    types: [closed, opened, labeled]
+    types: [closed, opened, labeled, synchronize]
 
 env:
   REPO_PATH: ${{ github.repository }}


### PR DESCRIPTION
This PR adds the synchronize event type to the changeset-release workflow to ensure it runs when PRs are updated.