### PR TITLE
fix: update workflow conditions to handle synchronize events

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -91,6 +91,7 @@ jobs:
       pull-requests: write
     if: >
         github.event_name == 'pull_request' &&
+        (github.event.action == 'opened' || github.event.action == 'labeled' || github.event.action == 'synchronize') &&
         github.event.pull_request.base.ref == 'main' &&
         github.actor == 'github-actions[bot]' &&
         contains(github.event.pull_request.title, 'Changeset version bump')


### PR DESCRIPTION
This PR updates the changeset-release workflow to properly handle synchronize events when the version bump PR is updated.