### PR TITLE
fix: add npm registry config and build step to release workflow

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -21,9 +21,13 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
         run: npm install
+
+      - name: Build
+        run: npm run build
 
       - name: Create Release Pull Request or Publish
         id: changesets


### PR DESCRIPTION
Fixes two issues in the release workflow:\n\n1. Adds proper npm registry configuration for authentication\n2. Adds build step to ensure dist/cli.cjs exists before publishing