### PR TITLE
feat: [DX-3360] cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,16 @@ pnpm global add hataraku
 import { createAgent, createTask } from 'hataraku';
 import { z } from 'zod';
 
-// Import provider creation functions
-import { createOpenRouterModel, createAnthropicModel } from 'hataraku';
-
-// Set up credentials (alternatively, use environment variables)
-// - OPENROUTER_API_KEY for OpenRouter
-// - ANTHROPIC_API_KEY for direct Anthropic access
-// - BEDROCK_ACCESS_KEY_ID and BEDROCK_SECRET_ACCESS_KEY for Amazon Bedrock
+// Bring in any ai-sdk provider https://sdk.vercel.ai/providers/ai-sdk-providers
+import { createOpenRouter } from "@openrouter/ai-sdk-provider"; 
 
 // Create an agent using Claude via OpenRouter
 // You can pass API key directly or use environment variable
-const model = await createOpenRouterModel('anthropic/claude-3-opus-20240229', process.env.OPENROUTER_API_KEY);
+const openrouter = createOpenRouter({
+  apiKey: 'YOUR_OPENROUTER_API_KEY',
+});
+const model = openrouter.chatModel('anthropic/claude-3.5-sonnet');
+
 const agent = createAgent({
   name: 'MyAgent',
   description: 'A helpful assistant',

--- a/examples/mcp.ts
+++ b/examples/mcp.ts
@@ -25,7 +25,7 @@ async function main() {
                             HOME: process.env.HOME || '/home/user',
                             PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin',
                         },
-                    },
+                    }
                 },
             },
         });
@@ -55,9 +55,9 @@ async function main() {
             console.log(chalk.cyan('\n📝 Agent Result:'));
             console.log(chalk.green(result));
             console.log();
-
         } finally {
             await disconnect();
+            process.exit(0);
         }
 
     } catch (error) {

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { ToolManager } from '../../config/ToolManager';
 import { input, select, confirm } from '@inquirer/prompts';
 import { ToolsConfig } from '../../config/toolConfig';
-import { McpClient } from '../../core/mcp/McpClient';
+import { McpClient } from '../../core/mcp/mcp-client';
 import { getMcpTools } from '../../core/mcp/toolWrapper';
 
 export function registerToolCommands(program: Command): Command {

--- a/src/core/__tests__/mcp/McpClient.test.ts
+++ b/src/core/__tests__/mcp/McpClient.test.ts
@@ -1,4 +1,4 @@
-import { McpClient } from '../../mcp/McpClient';
+import { McpClient } from '../../mcp/mcp-client';
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import * as fs from 'fs/promises';

--- a/src/core/mcp/mcp-client.ts
+++ b/src/core/mcp/mcp-client.ts
@@ -217,7 +217,7 @@ export class McpClient {
     /**
      * Call a tool on a specific server and parse its response
      */
-    async callTool<T = any>(serverName: string, toolName: string, args: Record<string, unknown>): Promise<ParsedMcpToolResponse<T>> {
+    async callTool<T = string>(serverName: string, toolName: string, args: Record<string, unknown>): Promise<ParsedMcpToolResponse<T>> {
         if (!this.initialized) {
             throw new Error('MCP servers have not been initialized');
         }
@@ -259,7 +259,11 @@ export class McpClient {
                 raw: response
             };
         } catch (error) {
-            throw new Error(`Failed to parse response from ${serverName}/${toolName}`);
+            // If the content is not JSON, return the content as a string
+            return {
+                data: content as T,
+                raw: response
+            };
         }
     }
 }

--- a/src/core/mcp/toolWrapper.ts
+++ b/src/core/mcp/toolWrapper.ts
@@ -1,5 +1,5 @@
 import { ToolSet, ToolExecutionOptions, jsonSchema } from 'ai';
-import { McpClient } from "./McpClient";
+import { McpClient } from "./mcp-client";
 import { McpConfig, McpConfigSchema, isMcpConfig } from './config';
 import { McpTool, ParsedMcpToolResponse } from './types';
 import { readFile } from 'node:fs/promises';


### PR DESCRIPTION
https://helloextend.atlassian.net/browse/DX-3360

### Description:
Refactors MCP client file naming and improves error handling for non-JSON responses.

### Type of Changes:
- Renames `McpClient.ts` to `mcp-client.ts` for consistent file naming conventions
- Enhances error handling to properly handle string responses
- Updates README examples to use modern AI SDK provider interface

### How can it be used:
The MCP client now properly handles non-JSON responses from tools:
```typescript
// Before: Would throw an error for non-JSON responses
// Now: Returns the content as a string when it's not valid JSON
```

### How did you test it:
All tests pass including the McpClient tests which verify the functionality.

### Notes for the reviewer:
The PR includes minor updates to the example code and README. Some linting warnings still exist but are unrelated to these changes.