### PR TITLE
fix: [DX-3415] profile delete via cli

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,6 +2,30 @@
 
 This document provides a comprehensive list of example commands to test various features of the Hataraku CLI.
 
+## Profile Management
+```bash
+# List all profiles
+hataraku profile list
+
+# Show profile details
+hataraku profile show <name>
+
+# Create a new profile
+hataraku profile create
+
+# Edit an existing profile
+hataraku profile edit <name>
+
+# Delete a profile
+hataraku profile delete <name>
+
+# Use a specific profile
+hataraku profile use <name>
+
+# Set knowledge base for a profile
+hataraku profile set-kb <name>
+```
+
 ## File Operations
 ```bash
 # Create a new file

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "name": "Michael Darmousseh"
   },
   "engines": {
-		"node": ">=20.0.0"
-	},
+    "node": ">=20.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/turlockmike/hataraku"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": {
     "name": "Michael Darmousseh"
   },
+  "engines": {
+		"node": ">=20.0.0"
+	},
   "repository": {
     "type": "git",
     "url": "https://github.com/turlockmike/hataraku"

--- a/src/__tests__/cli/commands/profile.test.ts
+++ b/src/__tests__/cli/commands/profile.test.ts
@@ -8,39 +8,39 @@ jest.mock("@inquirer/prompts")
 jest.mock("../../../config/ProfileManager")
 
 describe("profile commands", () => {
-	let program: Command
-	let mockDeleteProfile: jest.Mock
-	const mockConfirm = confirm as jest.MockedFunction<typeof confirm>
-	const mockProfileManager = ProfileManager as jest.MockedClass<typeof ProfileManager>
-	const mockExit = jest.spyOn(process, "exit").mockImplementation(() => undefined as never)
+  let program: Command
+  let mockDeleteProfile: jest.Mock
+  const mockConfirm = confirm as jest.MockedFunction<typeof confirm>
+  const mockProfileManager = ProfileManager as jest.MockedClass<typeof ProfileManager>
+  const mockExit = jest.spyOn(process, "exit").mockImplementation(() => undefined as never)
 
-	beforeEach(() => {
-		program = new Command()
-		registerProfileCommands(program)
-		mockDeleteProfile = jest.fn()
-		mockProfileManager.mockImplementation(() => ({ deleteProfile: mockDeleteProfile } as any))
-		mockExit.mockClear()
-	})
+  beforeEach(() => {
+    program = new Command()
+    registerProfileCommands(program)
+    mockDeleteProfile = jest.fn()
+    mockProfileManager.mockImplementation(() => ({ deleteProfile: mockDeleteProfile } as any))
+    mockExit.mockClear()
+  })
 
-	describe("delete command", () => {
-		it("should delete profile when confirmed", async () => {
-			mockConfirm.mockResolvedValueOnce(true)
-			await program.parseAsync(["node", "test", "profile", "delete", "test-profile"])
-			expect(mockDeleteProfile).toHaveBeenCalledWith("test-profile")
-		})
+  describe("delete command", () => {
+    it("should delete profile when confirmed", async () => {
+      mockConfirm.mockResolvedValueOnce(true)
+      await program.parseAsync(["node", "test", "profile", "delete", "test-profile"])
+      expect(mockDeleteProfile).toHaveBeenCalledWith("test-profile")
+    })
 
-		it("should not delete profile when not confirmed", async () => {
-			mockConfirm.mockResolvedValueOnce(false)
-			await program.parseAsync(["node", "test", "profile", "delete", "test-profile"])
-			expect(mockDeleteProfile).not.toHaveBeenCalled()
-		})
+    it("should not delete profile when not confirmed", async () => {
+      mockConfirm.mockResolvedValueOnce(false)
+      await program.parseAsync(["node", "test", "profile", "delete", "test-profile"])
+      expect(mockDeleteProfile).not.toHaveBeenCalled()
+    })
 
-		it("should handle deletion errors", async () => {
-			mockConfirm.mockResolvedValueOnce(true)
-			// @ts-expect-error Mocking error
-			mockDeleteProfile.mockRejectedValueOnce(new Error("Cannot delete active profile"))
-			await program.parseAsync(["node", "test", "profile", "delete", "test-profile"])
-			expect(mockExit).toHaveBeenCalledWith(1)
-		})
-	})
+    it("should handle deletion errors", async () => {
+      mockConfirm.mockResolvedValueOnce(true)
+      // @ts-expect-error Mocking error
+      mockDeleteProfile.mockRejectedValueOnce(new Error("Cannot delete active profile"))
+      await program.parseAsync(["node", "test", "profile", "delete", "test-profile"])
+      expect(mockExit).toHaveBeenCalledWith(1)
+    })
+  })
 })

--- a/src/__tests__/cli/commands/profile.test.ts
+++ b/src/__tests__/cli/commands/profile.test.ts
@@ -1,0 +1,46 @@
+import { jest } from "@jest/globals"
+import { Command } from "commander"
+import { confirm } from "@inquirer/prompts"
+import { ProfileManager } from "../../../config/ProfileManager"
+import { registerProfileCommands } from "../../../cli/commands/profile"
+
+jest.mock("@inquirer/prompts")
+jest.mock("../../../config/ProfileManager")
+
+describe("profile commands", () => {
+	let program: Command
+	let mockDeleteProfile: jest.Mock
+	const mockConfirm = confirm as jest.MockedFunction<typeof confirm>
+	const mockProfileManager = ProfileManager as jest.MockedClass<typeof ProfileManager>
+	const mockExit = jest.spyOn(process, "exit").mockImplementation(() => undefined as never)
+
+	beforeEach(() => {
+		program = new Command()
+		registerProfileCommands(program)
+		mockDeleteProfile = jest.fn()
+		mockProfileManager.mockImplementation(() => ({ deleteProfile: mockDeleteProfile } as any))
+		mockExit.mockClear()
+	})
+
+	describe("delete command", () => {
+		it("should delete profile when confirmed", async () => {
+			mockConfirm.mockResolvedValueOnce(true)
+			await program.parseAsync(["node", "test", "profile", "delete", "test-profile"])
+			expect(mockDeleteProfile).toHaveBeenCalledWith("test-profile")
+		})
+
+		it("should not delete profile when not confirmed", async () => {
+			mockConfirm.mockResolvedValueOnce(false)
+			await program.parseAsync(["node", "test", "profile", "delete", "test-profile"])
+			expect(mockDeleteProfile).not.toHaveBeenCalled()
+		})
+
+		it("should handle deletion errors", async () => {
+			mockConfirm.mockResolvedValueOnce(true)
+			// @ts-expect-error Mocking error
+			mockDeleteProfile.mockRejectedValueOnce(new Error("Cannot delete active profile"))
+			await program.parseAsync(["node", "test", "profile", "delete", "test-profile"])
+			expect(mockExit).toHaveBeenCalledWith(1)
+		})
+	})
+})

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -266,5 +266,29 @@ export function registerProfileCommands(program: Command): Command {
       }
     });
 
+  profileCommand
+		.command("delete <name>")
+		.description("Delete a profile")
+		.action(async (name: string) => {
+			try {
+				const profileManager = new ProfileManager()
+				const confirmed = await confirm({
+					message: `Are you sure you want to delete profile '${name}'?`,
+					default: false,
+				})
+
+				if (!confirmed) {
+					console.log(chalk.yellow("Profile deletion cancelled."))
+					return
+				}
+
+				await profileManager.deleteProfile(name)
+				console.log(chalk.green(`Profile '${name}' deleted successfully.`))
+			} catch (error) {
+				console.error(chalk.red("Error deleting profile:"), error)
+				process.exit(1)
+			}
+		})
+
   return program;
 } 

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -267,28 +267,28 @@ export function registerProfileCommands(program: Command): Command {
     });
 
   profileCommand
-		.command("delete <name>")
-		.description("Delete a profile")
-		.action(async (name: string) => {
-			try {
-				const profileManager = new ProfileManager()
-				const confirmed = await confirm({
-					message: `Are you sure you want to delete profile '${name}'?`,
-					default: false,
-				})
+    .command("delete <name>")
+    .description("Delete a profile")
+    .action(async (name: string) => {
+      try {
+        const profileManager = new ProfileManager()
+        const confirmed = await confirm({
+          message: `Are you sure you want to delete profile '${name}'?`,
+          default: false,
+        })
 
-				if (!confirmed) {
-					console.log(chalk.yellow("Profile deletion cancelled."))
-					return
-				}
+        if (!confirmed) {
+          console.log(chalk.yellow("Profile deletion cancelled."))
+          return
+        }
 
-				await profileManager.deleteProfile(name)
-				console.log(chalk.green(`Profile '${name}' deleted successfully.`))
-			} catch (error) {
-				console.error(chalk.red("Error deleting profile:"), error)
-				process.exit(1)
-			}
-		})
+        await profileManager.deleteProfile(name)
+        console.log(chalk.green(`Profile '${name}' deleted successfully.`))
+      } catch (error) {
+        console.error(chalk.red("Error deleting profile:"), error)
+        process.exit(1)
+      }
+    })
 
   return program;
 } 


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->
## Description

- Add profile delete to CLI
- Add node engine 20+ to package.json

## Type of change
<!-- Please ignore options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes -->

`npm run cli -- profile delete <profile name>`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Additional context
<!-- Add any other context or screenshots about the pull request here -->

## Related Issues
<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers
<!-- @mention specific team members or individuals who should review this PR -->